### PR TITLE
Add initial documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,28 @@
 language: csharp
+
 mono: none
+
 dotnet: 3.1.102
-script:
- - dotnet restore
+
+jobs:
+  include:
+    # Build
+    - stage: build
+      script:
+        - dotnet restore
+    
+    # Deploy docs
+    - stage: deploy_docs
+      name: deploy docs to cloudstate.io
+      if: repo = cloudstateio/dotnet-support AND ((branch = master AND type = push) OR tag =~ ^v)
+      language: scala
+      script: cd docs && sbt deploy
+
+stages:
+  - build
+  - deploy_docs
+
+env:
+  global:
+    # Docs deploy token encrypted with: travis encrypt --pro -r cloudstateio/dart-support DEPLOY_DOCS_TOKEN={token}
+    secure: "v+u7GSntZkypS2JF9dohQFf43stc18wsWoWSPs265L2RHQHYrVUT5RjiDGmTZ4LSDT3QRJfXFqsuLIAJKo0mZDCGAzZg3Jb1wOznZk0UChWrRyuizQevqRMlhbTz+NBI+to+mAozrMX7n/MH+OGdYTOlmRdr382ar36fe733WbqIMHhPakFSzKD2itUMsiEzIr9E0KWMjdIzcvzXD0BdtnBVfWG8KuwLUl4UqWZp6nwMOWXXLJp6VK5mHbXC4zk32Yx4wsShLIkDtI46Nlp3USi7WPaqvjJWUdEnyTtBZXeG0lsZ8x7qPU9R/8YaePYlN1yuASuCN40vzbZk4aXXNfNvL1Cqs+U+ln4qsNkBs2L93yWN3DFLBfB+Sp/9QaGps1KW9AbZI9M7Na8sK3CsW0GAwMuvoDuDFHlh3QXoTQag0V+C3KcxRJwgd99QDejkFjQK7iyPRVBsb8rgHJOKYMlQRv+TzXiahRBwu+kqdu+ZZ4yY4FA7bzN3XM+Zb4PgvVpyYzNM0NfDuLGpXM6NoKiUXrdXPiE15iWxgNCpygKOwefYsexdCEfY2158NlpDoYaOtfRHDZSuPnuv0unM+jB2x1BHblD6xBESEto0m1+M1CFqBgIx9TV0+bgXIrsmuSch9VMkoPXFi2BeEBxViMBJrKxLEL77tYBVvKaTReU="

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,23 @@
+# Cloudstate .Net documentation
+
+Documentation source for Cloudstate .Net C# support, published to https://cloudstate.io/docs/dotnet/current/
+
+To build the docs with [sbt](https://www.scala-sbt.org):
+
+```
+sbt paradox
+```
+
+Can also first start the sbt interactive shell with `sbt`, then run commands.
+
+The documentation can be viewed locally by opening the generated pages:
+
+```
+open target/paradox/site/main/index.html
+```
+
+To watch files for changes and rebuild docs automatically:
+
+```
+sbt ~paradox
+```

--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -1,0 +1,13 @@
+
+lazy val docs = project
+  .in(file("."))
+  .enablePlugins(CloudstateParadoxPlugin)
+  .settings(
+    deployModule := "dotnet",
+    paradoxProperties in Compile ++= Map(
+      "cloudstate.dotnet.version" -> "2.2",
+      "cloudstate.dotnet-support.version" -> { if (isSnapshot.value) previousStableVersion.value.getOrElse("0.0.0") else version.value },
+      "extref.cloudstate.base_url" -> "https://cloudstate.io/docs/core/current/%s",
+      "snip.base.base_dir" -> s"${(baseDirectory in ThisBuild).value.getAbsolutePath}/../",
+    )
+  )

--- a/docs/project/build.properties
+++ b/docs/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.3.12

--- a/docs/project/plugins.sbt
+++ b/docs/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")
+addSbtPlugin("io.cloudstate" % "sbt-cloudstate-paradox" % "0.1.2")

--- a/docs/src/main/paradox/crdt.md
+++ b/docs/src/main/paradox/crdt.md
@@ -1,0 +1,3 @@
+# CRDT
+
+* Explain how to use the CRDT API

--- a/docs/src/main/paradox/eventsourced.md
+++ b/docs/src/main/paradox/eventsourced.md
@@ -1,0 +1,93 @@
+# Event sourcing
+
+This page documents how to implement Cloudstate event sourced entities in .Net C#. For information on what Cloudstate event sourced entities are, please read the general @extref:[Event sourcing](cloudstate:user/features/eventsourced.html) documentation first.
+
+An event sourced entity can be created by annotating it with the `[EventSourcedEntity]` attribute.
+
+@@snip [EventSourcedEntity.cs]($base$/docs/src/test/eventsourced/EventSourcedEntity.cs) { #entity-class }
+
+## Persistence types and serialization
+
+Event sourced entities persist events and snapshots, and these need to be serialized when persisted. The most straight forward way to persist events and snapshots is to use protobufs. Cloudstate will automatically detect if an emitted event is a protobuf, and serialize it as such. For other serialization options, including JSON, see @ref:[Serialization](serialization.md).
+
+While protobufs are the recommended format for persisting events, it is recommended that you do not persist your services protobuf messages, rather, you should create new messages, even if they are identical to the services. While this may introduce some overhead in needing to convert from one type to the other, the reason for doing this is that it will allow the services public interface to evolve independently from its data storage format, which should be private.
+
+For our shopping cart example, we'll create a new file called `domain.proto`, the name domain is selected to indicate that these are my applications domain objects:
+
+@@snip [domain.proto]($base$/docs/src/test/proto/domain.proto)
+
+## State
+
+Each entity should store its state locally in a mutable variable, either a mutable field or a multiple structure such as a collection. For our shopping cart, the state is a dictionary of product ids to products, so we'll create a dictionary to contain that:
+
+@@snip [EventSourcedEntity.cs]($base$/docs/src/test/eventsourced/EventSourcedEntity.cs) { #entity-state }
+
+## Constructing
+
+While you don't necessarily need to define a constructor, you can define one and have that context and EntityId injected in. Use the `[EntityId]` attribute to indicate where the EntityId value will be set.
+
+The constructor below shows having the entity id injected:
+
+@@snip [EventSourcedEntity.cs]($base$/docs/src/test/eventsourced/EventSourcedEntity.cs) { #constructing }
+
+## Handling commands
+
+Command handlers can be declared by annotating a method with `[CommandHandler]` attribute. They take a context class of type `ICommandContext`.
+
+By default, the name of the command that the method handles will be the name of the method with the first letter capitalized. So, a method called `GetCart` will handle gRPC service call command named `GetCart`.
+
+The return type of the command handler must be the output type for the gRPC service call, this will be sent as the reply.
+
+The following shows the implementation of the `GetCart` command handler. This command handler is a read-only command handler, it doesn't emit any events, it just returns some state:
+
+@@snip [EventSourcedEntity.cs]($base$/docs/src/test/eventsourced/EventSourcedEntity.cs) { #get-cart }
+
+### Emitting events
+
+Commands that modify the state may do so by emitting events.
+
+@@@ warning
+The **only** way a command handler may modify its state is by emitting an event. Any modifications made directly to the state from the command handler will not be persisted, and when the entity is passivated and next reloaded, those modifications will not be present.
+@@@
+
+A command handler may emit an event by taking in a `ICommandContext` parameter, and invoking the `emit` method on it. Invoking `emit` will immediately invoke the associated event handler for that event - this both validates that the event can be applied to the current state, as well as updates the state so that subsequent processing in the command handler can use it.
+
+Here's an example of a command handler that emits an event:
+
+@@snip [EventSourcedEntity.cs]($base$/docs/src/test/eventsourced/EventSourcedEntity.cs) { #add-item }
+
+This command handler also validates the command, ensuring the quantity items added is greater than zero. Invoking `ctx.fail` fails the command - this method throws so there's no need to explicitly throw an exception.
+
+## Handling events
+
+Event handlers are invoked at two points, when restoring entities from the journal, before any commands are handled, and each time a new event is emitted. An event handlers responsibility is to update the state of the entity according to the event. Event handlers are the only place where its safe to mutate the state of the entity at all.
+
+Event handlers are declared by annotating a method with ` [EventHandler(typeof(Type))]` attribute. They take a context class of type `IEventBehaviorContext`.
+
+Event handlers are differentiated by the type of event they handle in `EventHandler` attribute.
+
+Here's an example event handler for the `ItemRemoved` event.
+
+@@snip [EventSourcedEntity.cs]($base$/docs/src/test/eventsourced/EventSourcedEntity.cs) { #item-removed }
+
+## Producing and handling snapshots
+
+Snapshots are an important optimisation for event sourced entities that may contain many events, to ensure that they can be loaded quickly even when they have very long journals. To produce a snapshot, a method annotated with `[Snapshot]` attribute must be declared. It takes a context class of type `ISnapshotContext`, and must return a snapshot of the current state in serializable form. 
+
+@@snip [EventSourcedEntity.cs]($base$/docs/src/test/eventsourced/EventSourcedEntity.cs) { #snapshot }
+
+When the entity is loaded again, the snapshot will first be loaded before any other events are received, and passed to a snapshot handler. Snapshot handlers are declare by annotating a method with `[SnapshotHandler]` attribute, and it can take a context class of type `ISnapshotContext`.
+
+Multiple snapshot handlers may be defined to handle multiple different types of snapshots, the type matching is done in the same way as for events.
+
+@@snip [EventSourcedEntity.cs]($base$/docs/src/test/eventsourced/EventSourcedEntity.cs) { #handle-snapshot }
+
+## Registering the entity
+
+Once you've created your entity, you can register it with the `CloudState` server, by invoking the `RegisterEventSourcedEntity<EntityType>` method. In addition to passing the protobuf descriptors and any other additional descriptors you use.
+
+@@snip [Program.cs]($base$/docs/src/test/eventsourced/Program.cs) { #register }
+
+The complete code for our entity class would look like this:
+
+@@snip [ShoppingCartEntity.cs]($base$/docs/src/test/eventsourced/ShoppingCartEntity.cs) { #entity-content }

--- a/docs/src/main/paradox/examples.md
+++ b/docs/src/main/paradox/examples.md
@@ -1,0 +1,5 @@
+# Examples
+
+You can find more usage examples by visiting the [project page](https://github.com/cloudstateio/dotnet-support/tree/master/examples).
+
+Enjoy.

--- a/docs/src/main/paradox/gettingstarted.md
+++ b/docs/src/main/paradox/gettingstarted.md
@@ -1,0 +1,14 @@
+# Getting started
+
+## Prerequisites
+
+### .Net Core SDK version
+Cloudstate .Net support requires .Net Core sdk $cloudstate.dotnet.version$.
+
+## Creating a main function
+
+Your main class will be responsible for creating the Cloudstate gRPC server, registering the entities for your placement and starting it:
+
+@@snip [Program.cs]($base$/docs/src/test/eventsourced/Program.cs) { #main }
+
+We will see more details on creating entities in the coming pages.

--- a/docs/src/main/paradox/gettingstarted.md
+++ b/docs/src/main/paradox/gettingstarted.md
@@ -5,6 +5,10 @@
 ### .Net Core SDK version
 Cloudstate .Net support requires .Net Core sdk $cloudstate.dotnet.version$.
 
+## Creating Entity
+
+You must create an Entity Function with your business logic. @ref:[Here](eventsourced.md) and @ref:[here](crdt.md) you will find good examples of how to do this for EventSourced and CRDT entities respectively.
+
 ## Creating a main function
 
 Your main class will be responsible for creating the Cloudstate gRPC server, registering the entities for your placement and starting it:
@@ -12,3 +16,84 @@ Your main class will be responsible for creating the Cloudstate gRPC server, reg
 @@snip [Program.cs]($base$/docs/src/test/eventsourced/Program.cs) { #main }
 
 We will see more details on creating entities in the coming pages.
+
+## Run with Docker
+
+Cloudstate requires you to run your applications via [Docker](https://www.docker.com/) containers. Here we explain how you can package your applications and how you can test them locally.
+
+### Instructions
+
+* Create Dockerfile
+
+```
+ARG MAIN_DLL
+ARG ARTIFACT_PATH
+ARG NETCORE_VERSION=2.2
+FROM mcr.microsoft.com/dotnet/core/runtime:$NETCORE_VERSION as runtime
+
+ARG MAIN_DLL
+ARG ARTIFACT_PATH
+
+ENV MAIN_DLL=${MAIN_DLL}
+
+RUN env
+
+COPY ${ARTIFACT_PATH}/ /app
+
+EXPOSE 8080
+
+ENTRYPOINT dotnet /app/$MAIN_DLL
+```
+
+* Build the docker image
+
+```
+# Build the docker image
+CONFIGURATION="Debug"
+FRAMEWORK="netcoreapp2.2"
+
+dotnet publish -c $CONFIGURATION -f $FRAMEWORK &&
+docker build \
+    -t nagytech/cloudstate-csharp/shopping-cart \
+    --build-arg ARTIFACT_PATH="bin/$CONFIGURATION/$FRAMEWORK/publish" \
+    --build-arg MAIN_DLL="EventSourced.ShoppingCart.dll" \
+    --no-cache .
+```
+
+* Run the CloudState Proxy operator image in dev mode
+
+```
+# Run the operator image first
+docker run -it --rm \
+    --name cloudstate \
+    -p 9000:9000 \
+    cloudstateio/cloudstate-proxy-dev-mode
+```
+
+* Run the recently built docker image and attach it to the 
+   network of the CloudState proxy container
+
+```
+# Run the user function and attach the network
+docker run -it --rm \
+    --name shopping-cart \
+    --network container:cloudstate \
+    nagytech/cloudstate-csharp/shopping-cart
+```
+
+* Call the CloudState proxy and list all the services
+
+```
+# Example using grpc_cli
+> grpc_cli ls localhost:9000 -l
+
+filename: example/shoppingcart/shoppingcart.proto
+package: com.example.shoppingcart;
+service ShoppingCart {
+  rpc AddItem(com.example.shoppingcart.AddLineItem) returns (google.protobuf.Empty) {}
+  rpc RemoveItem(com.example.shoppingcart.RemoveLineItem) returns (google.protobuf.Empty) {}
+  rpc GetCart(com.example.shoppingcart.GetShoppingCart) returns (com.example.shoppingcart.Cart) {}
+}
+
+```
+

--- a/docs/src/main/paradox/index.md
+++ b/docs/src/main/paradox/index.md
@@ -8,6 +8,7 @@ Cloudstate offers an idiomatic, annotation based .Net C# support library for wri
 
 * [Getting started](gettingstarted.md)
 * [Event sourcing](eventsourced.md)
+* [Stateless Functions](stateless.md)
 * [Conflict-free Replicated Data Types](crdt.md)
 * [Examples](examples.md)
 * [Serialization](serialization.md)

--- a/docs/src/main/paradox/index.md
+++ b/docs/src/main/paradox/index.md
@@ -1,0 +1,17 @@
+# .Net
+
+Cloudstate offers an idiomatic, annotation based .Net C# support library for writing stateful services.
+
+@@toc { depth=1 }
+
+@@@ index
+
+* [Getting started](gettingstarted.md)
+* [Event sourcing](eventsourced.md)
+* [Conflict-free Replicated Data Types](crdt.md)
+* [Examples](examples.md)
+* [Serialization](serialization.md)
+
+@@@
+
+Link to @extref:[Cloudstate Documentation](cloudstate:index.html)

--- a/docs/src/main/paradox/index.md
+++ b/docs/src/main/paradox/index.md
@@ -1,4 +1,4 @@
-# .Net
+# Cloudstate .Net
 
 Cloudstate offers an idiomatic, annotation based .Net C# support library for writing stateful services.
 

--- a/docs/src/main/paradox/serialization.md
+++ b/docs/src/main/paradox/serialization.md
@@ -1,0 +1,6 @@
+# Serialization
+
+Cloudstate functions serve gRPC interfaces, and naturally the input messages and output messages are protobuf messages that get serialized to the protobuf wire format. However, in addition to these messages, there are a number of places where Cloudstate needs to serialize other objects, for persistence and replication.
+
+See @extref:[here](cloudstate:user/lang/java/serialization.html) for more details
+

--- a/docs/src/main/paradox/stateless.md
+++ b/docs/src/main/paradox/stateless.md
@@ -1,0 +1,3 @@
+# Stateless
+
+* Explain how to use the Stateless API

--- a/docs/src/test/eventsourced/EventSourcedEntity.cs
+++ b/docs/src/test/eventsourced/EventSourcedEntity.cs
@@ -1,0 +1,124 @@
+
+// #constructing
+public ShoppingCartEntity([EntityId]String entityId)
+{
+    EntityId = entityId;
+    Cart = new Dictionary<string, Com.Example.Shoppingcart.LineItem>();
+}
+// #constructing
+
+// #entity-class
+namespace EventSourced.ShoppingCart
+{
+    [EventSourcedEntity]
+    public class ShoppingCartEntity
+    {
+        // ...
+    }
+// #entity-class
+
+    // #entity-state
+    Dictionary<String, Com.Example.Shoppingcart.LineItem> Cart { get; }
+    // #entity-state
+
+    // #snapshot
+    [Snapshot]
+    public Cart Snapshot()
+    {
+        var cart = new Cart();
+        cart.Items.AddRange(Cart.Select(x => Convert(x.Value)));
+        return cart;
+    }
+
+    Com.Example.Shoppingcart.LineItem Convert(LineItem item)
+    {
+        var lineItem = new Com.Example.Shoppingcart.LineItem();
+        lineItem.ProductId = item.ProductId;
+        lineItem.Name = item.Name;
+        lineItem.Quantity = item.Quantity;
+        return lineItem;
+    }
+    // #snapshot
+
+    // #handle-snapshot
+    [SnapshotHandler]
+    public void HandleSnapshot(Cart cart)
+    {
+        Cart.Clear();
+        foreach (LineItem item in cart.Items)
+        {
+            Cart.Add(item.ProductId, Convert(item));
+        }
+    }
+
+    LineItem Convert(Com.Example.Shoppingcart.LineItem item) =>
+    new LineItem()
+    {
+        ProductId = item.ProductId,
+        Name = item.Name,
+        Quantity = item.Quantity
+    };
+    // #handle-snapshot
+
+    // #item-added
+    [EventHandler(typeof(ItemAdded))]
+    public void ItemAdded(ItemAdded itemAdded)
+    {
+        Cart.TryGetValue(itemAdded.Item.ProductId, out var item);
+        if (item == null)
+        {
+            item = Convert(itemAdded.Item);
+            Cart.Add(item.ProductId, item);
+        }
+        else
+        {
+            item = new Com.Example.Shoppingcart.LineItem(item)
+            {
+                Quantity = item.Quantity + itemAdded.Item.Quantity
+            };
+            Cart[item.ProductId] = item;
+        }
+    }
+    // #item-added
+
+    // #item-removed
+    [EventHandler(typeof(ItemRemoved))]
+    public void itemRemoved(ItemRemoved itemRemoved, IEventBehaviorContext c)
+    {
+        Cart.Remove(itemRemoved.ProductId);
+    }
+    // #item-removed
+
+    // #get-cart
+    [CommandHandler]
+    public Com.Example.Shoppingcart.Cart GetCart()
+    {
+        var cart = new Com.Example.Shoppingcart.Cart();
+        cart.Items.AddRange(Cart.Values);
+        return cart;
+    }
+    // #get-cart
+
+    // #add-item
+    [CommandHandler]
+    public Empty AddItem(Com.Example.Shoppingcart.AddLineItem item, ICommandContext ctx)
+    {
+        if (item.Quantity <= 0)
+        {
+            ctx.Fail("Cannot add negative quantity of to item" + item.ProductId);
+        }
+        ctx.Emit(
+            new ItemAdded()
+            {
+                Item = new LineItem()
+                {
+                    ProductId = item.ProductId,
+                    Quantity = item.Quantity
+                }
+            }
+        );
+        return new Empty();
+    }
+    // #add-item
+
+}

--- a/docs/src/test/eventsourced/Program.cs
+++ b/docs/src/test/eventsourced/Program.cs
@@ -1,0 +1,23 @@
+// #main
+using System.Threading.Tasks;
+using Google.Protobuf;
+
+namespace EventSourced.ShoppingCart
+{
+    public static class Program
+    {
+        public static async Task Main()
+        {
+            // #register
+            var state = new CloudState.CSharpSupport.CloudState()
+                    .RegisterEventSourcedEntity<ShoppingCartEntity>(
+                        Com.Example.Shoppingcart.ShoppingCart.Descriptor,
+                        Com.Example.Shoppingcart.Persistence.DomainReflection.Descriptor
+                    );
+
+            await state.StartAsync();
+            // #register
+        }
+    }
+}
+// #main

--- a/docs/src/test/eventsourced/ShoppingCartEntity.cs
+++ b/docs/src/test/eventsourced/ShoppingCartEntity.cs
@@ -1,0 +1,119 @@
+// #entity-content
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using CloudState.CSharpSupport.Attributes;
+using CloudState.CSharpSupport.Attributes.EventSourced;
+using CloudState.CSharpSupport.Interfaces.EventSourced.Contexts;
+using Com.Example.Shoppingcart.Persistence;
+using Google.Protobuf.WellKnownTypes;
+
+namespace EventSourced.ShoppingCart
+{
+    [EventSourcedEntity]
+    [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global")]
+    [SuppressMessage("ReSharper", "UnusedMember.Global")]
+    public class ShoppingCartEntity
+    {
+        String EntityId { get; }
+
+        Dictionary<String, Com.Example.Shoppingcart.LineItem> Cart { get; }
+
+        public ShoppingCartEntity([EntityId]String entityId)
+        {
+            EntityId = entityId;
+            Cart = new Dictionary<string, Com.Example.Shoppingcart.LineItem>();
+        }
+
+        [Snapshot]
+        public Cart Snapshot()
+        {
+            var cart = new Cart();
+            cart.Items.AddRange(Cart.Select(x => Convert(x.Value)));
+            return cart;
+        }
+
+        [SnapshotHandler]
+        public void HandleSnapshot(Cart cart)
+        {
+            Cart.Clear();
+            foreach (LineItem item in cart.Items)
+            {
+                Cart.Add(item.ProductId, Convert(item));
+            }
+        }
+
+        [EventHandler(typeof(ItemAdded))]
+        public void ItemAdded(ItemAdded itemAdded)
+        {
+            Cart.TryGetValue(itemAdded.Item.ProductId, out var item);
+            if (item == null)
+            {
+                item = Convert(itemAdded.Item);
+                Cart.Add(item.ProductId, item);
+            }
+            else
+            {
+                item = new Com.Example.Shoppingcart.LineItem(item)
+                {
+                    Quantity = item.Quantity + itemAdded.Item.Quantity
+                };
+                Cart[item.ProductId] = item;
+            }
+        }
+
+        [EventHandler(typeof(ItemRemoved))]
+        public void itemRemoved(ItemRemoved itemRemoved, IEventBehaviorContext c)
+        {
+            Cart.Remove(itemRemoved.ProductId);
+        }
+
+        [CommandHandler]
+        public Com.Example.Shoppingcart.Cart GetCart()
+        {
+            var cart = new Com.Example.Shoppingcart.Cart();
+            cart.Items.AddRange(Cart.Values);
+            return cart;
+        }
+
+        [CommandHandler]
+        public Empty AddItem(Com.Example.Shoppingcart.AddLineItem item, ICommandContext ctx)
+        {
+            if (item.Quantity <= 0)
+            {
+                ctx.Fail("Cannot add negative quantity of to item" + item.ProductId);
+            }
+            ctx.Emit(
+                new ItemAdded()
+                {
+                    Item = new LineItem()
+                    {
+                        ProductId = item.ProductId,
+                        Quantity = item.Quantity
+                    }
+                }
+            );
+            return new Empty();
+        }
+
+        Com.Example.Shoppingcart.LineItem Convert(LineItem item)
+        {
+            var lineItem = new Com.Example.Shoppingcart.LineItem();
+            lineItem.ProductId = item.ProductId;
+            lineItem.Name = item.Name;
+            lineItem.Quantity = item.Quantity;
+            return lineItem;
+        }
+
+        LineItem Convert(Com.Example.Shoppingcart.LineItem item) =>
+          new LineItem()
+          {
+              ProductId = item.ProductId,
+              Name = item.Name,
+              Quantity = item.Quantity
+          };
+
+    }
+}
+// #entity-content

--- a/docs/src/test/proto/domain.proto
+++ b/docs/src/test/proto/domain.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+
+package example.shoppingcart.domain;
+
+option java_package = "com.example";
+
+message LineItem {
+    string productId = 1;
+    string name = 2;
+    int32 quantity = 3;
+}
+
+message ItemAdded {
+    LineItem item = 1;
+}
+
+message ItemRemoved {
+    string productId = 1;
+}
+
+message CheckedOut {}
+
+message Cart {
+    repeated LineItem items = 1;
+    bool checkedout = 2;
+}

--- a/docs/src/test/proto/hotitems.proto
+++ b/docs/src/test/proto/hotitems.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+import "cloudstate/entity_key.proto";
+
+package example.shoppingcart;
+
+option java_package = "com.example";
+
+service HotItemsService {
+    rpc ItemAddedToCart(Item) returns (google.protobuf.Empty);
+}
+
+message Item {
+    string product_id = 1;
+    string name = 2;
+    int32 quantity = 3;
+}
+

--- a/docs/src/test/proto/shoppingcart.proto
+++ b/docs/src/test/proto/shoppingcart.proto
@@ -1,0 +1,41 @@
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+import "cloudstate/entity_key.proto";
+
+package example.shoppingcart;
+
+option java_package = "com.example";
+
+service ShoppingCartService {
+    rpc AddItem(AddLineItem) returns (google.protobuf.Empty);
+    rpc RemoveItem(RemoveLineItem) returns (google.protobuf.Empty);
+    rpc GetCart(GetShoppingCart) returns (Cart);
+    rpc WatchCart(GetShoppingCart) returns (stream Cart);
+}
+
+message AddLineItem {
+    string user_id = 1 [(.cloudstate.entity_key) = true];
+    string product_id = 2;
+    string name = 3;
+    int32 quantity = 4;
+}
+
+message RemoveLineItem {
+    string user_id = 1 [(.cloudstate.entity_key) = true];
+    string product_id = 2;
+}
+
+message GetShoppingCart {
+    string user_id = 1 [(.cloudstate.entity_key) = true];
+}
+
+message LineItem {
+    string product_id = 1;
+    string name = 2;
+    int32 quantity = 3;
+}
+
+message Cart {
+    repeated LineItem items = 1;
+}


### PR DESCRIPTION
I think it's important that we include some documentation to support dotnet C#. Many people may not even know that we provide support for this language as we have no reference to it in the documentation. So I am humbly forwarding an initial version of documentation.
Some work must be added later mainly on the gettingstarted page because, I do not explain details about the initial build. I think @nagytech can explain these details better later.

I was not able to explicitly add the reviewers because I am not part of the C# team but I think @nagytech and @pvlugter, maybe @marcellanz or @viktorklang can also take a look at this PR.

PS.: It is not part of this PR but maybe it would be interesting to include myself in the C# team since I periodically contribute here. It would be nice to have someone else anyway.